### PR TITLE
Fix addRequestTarget not affect anything.

### DIFF
--- a/signing.go
+++ b/signing.go
@@ -182,12 +182,12 @@ func setSignatureHeader(h http.Header, targetHeader, pubKeyId, algo, enc string,
 	h.Add(targetHeader, b.String())
 }
 
-func requestTargetNotPermitted(b bytes.Buffer) error {
+func requestTargetNotPermitted(b *bytes.Buffer) error {
 	return fmt.Errorf("cannot sign with %q on anything other than an http request", RequestTarget)
 }
 
-func addRequestTarget(r *http.Request) func(b bytes.Buffer) error {
-	return func(b bytes.Buffer) error {
+func addRequestTarget(r *http.Request) func(b *bytes.Buffer) error {
+	return func(b *bytes.Buffer) error {
 		b.WriteString(RequestTarget)
 		b.WriteString(headerFieldDelimiter)
 		b.WriteString(strings.ToLower(r.Method))
@@ -197,7 +197,7 @@ func addRequestTarget(r *http.Request) func(b bytes.Buffer) error {
 	}
 }
 
-func signatureString(values http.Header, include []string, requestTargetFn func(b bytes.Buffer) error) (string, error) {
+func signatureString(values http.Header, include []string, requestTargetFn func(b *bytes.Buffer) error) (string, error) {
 	if len(include) == 0 {
 		include = defaultHeaders
 	}
@@ -205,7 +205,7 @@ func signatureString(values http.Header, include []string, requestTargetFn func(
 	for n, i := range include {
 		i := strings.ToLower(i)
 		if i == RequestTarget {
-			err := requestTargetFn(b)
+			err := requestTargetFn(&b)
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
When Sign and Verify, (request-target) are ignored.
Because func addRequestTarget() receive Buffer b as call by value,
so inner processing don't affect b in signatureString().

Tests response ok, because signing and verifing takes same mistake.
I don't have good idea to fix them now.