### PR TITLE
Add appendix C tests

### DIFF
--- a/signing.go
+++ b/signing.go
@@ -106,6 +106,7 @@ func (a *asymmSigner) SignRequest(pKey crypto.PrivateKey, pubKeyId string, r *ht
 	if err != nil {
 		return err
 	}
+
 	enc, err := a.signSignature(pKey, s)
 	if err != nil {
 		return err
@@ -200,6 +201,12 @@ func addRequestTarget(r *http.Request) func(b *bytes.Buffer) error {
 		b.WriteString(strings.ToLower(r.Method))
 		b.WriteString(requestTargetSeparator)
 		b.WriteString(r.URL.Path)
+
+		if r.URL.RawQuery != "" {
+			b.WriteString("?")
+			b.WriteString(r.URL.RawQuery)
+		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
Adds test from appendix C of the spec.

Note: C.1. is currently failing:

`headers="date"` should not be added to the signature string, if I read the spec correctly


>  If a list of headers is not included, the date is the only header
   that is signed by default.  The string to sign would be:

>   date: Sun, 05 Jan 2014 21:31:40 GMT

 >  The Authorization header would be:

 >  Authorization: Signature keyId="Test",algorithm="rsa-sha256",
   signature="SjWJWbWN7i0wzBvtPl8rbASWz5xQW6mcJmn+ibttBqtifLN7Sazz
   6m79cNfwwb8DMJ5cou1s7uEGKKCs+FLEEaDV5lp7q25WqS+lavg7T8hc0GppauB
   6hbgEKTwblDHYGEtbGmtdHgVCk9SuS13F0hZ8FD0k/5OxEPXe5WozsbM="


* Note ☝️ that there is no `headers` list in this string
Signed-off-by: Edward Wilde <ewilde@gmail.com>

* This PR includes a fix to the signer to include the full path with query string if present