### PR TITLE
Adds support for crated and expires values

### DIFF
--- a/httpsig.go
+++ b/httpsig.go
@@ -8,6 +8,7 @@
 package httpsig
 
 import (
+        "time"
 	"crypto"
 	"fmt"
 	"net/http"
@@ -147,15 +148,15 @@ type Signer interface {
 //
 // An error is returned if an unknown or a known cryptographically insecure
 // Algorithm is provided.
-func NewSigner(prefs []Algorithm, dAlgo DigestAlgorithm, headers []string, scheme SignatureScheme) (Signer, Algorithm, error) {
+func NewSigner(prefs []Algorithm, dAlgo DigestAlgorithm, headers []string, scheme SignatureScheme, expiresIn int64) (Signer, Algorithm, error) {
 	for _, pref := range prefs {
-		s, err := newSigner(pref, dAlgo, headers, scheme)
+		s, err := newSigner(pref, dAlgo, headers, scheme, expiresIn)
 		if err != nil {
 			continue
 		}
 		return s, pref, err
 	}
-	s, err := newSigner(defaultAlgorithm, dAlgo, headers, scheme)
+	s, err := newSigner(defaultAlgorithm, dAlgo, headers, scheme, expiresIn)
 	return s, defaultAlgorithm, err
 }
 
@@ -201,20 +202,27 @@ func NewVerifier(r *http.Request) (Verifier, error) {
 	if _, hasHostHeader := h[hostHeader]; len(r.Host) > 0 && !hasHostHeader {
 		h[hostHeader] = []string{r.Host}
 	}
-	return newVerifier(h, func(h http.Header, toInclude []string) (string, error) {
-		return signatureString(h, toInclude, addRequestTarget(r))
+	return newVerifier(h, func(h http.Header, toInclude []string, created int64, expires int64) (string, error) {
+		return signatureString(h, toInclude, addRequestTarget(r), created, expires)
 	})
 }
 
 // NewResponseVerifier verifies the given response. It returns errors under the
 // same conditions as NewVerifier.
 func NewResponseVerifier(r *http.Response) (Verifier, error) {
-	return newVerifier(r.Header, func(h http.Header, toInclude []string) (string, error) {
-		return signatureString(h, toInclude, requestTargetNotPermitted)
+	return newVerifier(r.Header, func(h http.Header, toInclude []string, created int64, expires int64) (string, error) {
+		return signatureString(h, toInclude, requestTargetNotPermitted, created, expires)
 	})
 }
 
-func newSigner(algo Algorithm, dAlgo DigestAlgorithm, headers []string, scheme SignatureScheme) (Signer, error) {
+func newSigner(algo Algorithm, dAlgo DigestAlgorithm, headers []string, scheme SignatureScheme, expiresIn int64) (Signer, error) {
+
+        var expires, created int64 = 0, 0
+        if expiresIn != 0 {
+                created = time.Now().Unix()
+                expires = created + expiresIn
+        }
+
 	s, err := signerFromString(string(algo))
 	if err == nil {
 		a := &asymmSigner{
@@ -223,6 +231,8 @@ func newSigner(algo Algorithm, dAlgo DigestAlgorithm, headers []string, scheme S
 			headers:      headers,
 			targetHeader: scheme,
 			prefix:       scheme.authScheme(),
+                        created:      created,
+                        expires:      expires,
 		}
 		return a, nil
 	}
@@ -236,6 +246,9 @@ func newSigner(algo Algorithm, dAlgo DigestAlgorithm, headers []string, scheme S
 		headers:      headers,
 		targetHeader: scheme,
 		prefix:       scheme.authScheme(),
+                created:      created,
+                expires:      expires,
+
 	}
 	return c, nil
 }

--- a/signing.go
+++ b/signing.go
@@ -1,6 +1,7 @@
 package httpsig
 
 import (
+        "strconv"
 	"bytes"
 	"crypto"
 	"crypto/rand"
@@ -25,6 +26,8 @@ const (
 	// RequestTarget specifies to include the http request method and
 	// entire URI in the signature. Pass it as a header to NewSigner.
 	RequestTarget = "(request-target)"
+        createdKey    = "created"
+        expiresKey    = "expires"
 	dateHeader    = "date"
 
 	// Signature String Construction
@@ -45,6 +48,8 @@ type macSigner struct {
 	headers      []string
 	targetHeader SignatureScheme
 	prefix       string
+        created      int64
+        expires      int64
 }
 
 func (m *macSigner) SignRequest(pKey crypto.PrivateKey, pubKeyId string, r *http.Request, body []byte) error {
@@ -62,7 +67,7 @@ func (m *macSigner) SignRequest(pKey crypto.PrivateKey, pubKeyId string, r *http
 	if err != nil {
 		return err
 	}
-	setSignatureHeader(r.Header, string(m.targetHeader), m.prefix, pubKeyId, m.m.String(), enc, m.headers)
+	setSignatureHeader(r.Header, string(m.targetHeader), m.prefix, pubKeyId, m.m.String(), enc, m.headers, m.created, m.expires)
 	return nil
 }
 
@@ -81,7 +86,7 @@ func (m *macSigner) SignResponse(pKey crypto.PrivateKey, pubKeyId string, r http
 	if err != nil {
 		return err
 	}
-	setSignatureHeader(r.Header(), string(m.targetHeader), m.prefix, pubKeyId, m.m.String(), enc, m.headers)
+	setSignatureHeader(r.Header(), string(m.targetHeader), m.prefix, pubKeyId, m.m.String(), enc, m.headers, m.created, m.expires)
 	return nil
 }
 
@@ -99,11 +104,11 @@ func (m *macSigner) signSignature(pKey crypto.PrivateKey, s string) (string, err
 }
 
 func (m *macSigner) signatureString(r *http.Request) (string, error) {
-	return signatureString(r.Header, m.headers, addRequestTarget(r))
+	return signatureString(r.Header, m.headers, addRequestTarget(r), m.created, m.expires)
 }
 
 func (m *macSigner) signatureStringResponse(r http.ResponseWriter) (string, error) {
-	return signatureString(r.Header(), m.headers, requestTargetNotPermitted)
+	return signatureString(r.Header(), m.headers, requestTargetNotPermitted, m.created, m.expires)
 }
 
 var _ Signer = &asymmSigner{}
@@ -115,6 +120,8 @@ type asymmSigner struct {
 	headers      []string
 	targetHeader SignatureScheme
 	prefix       string
+        created      int64
+        expires      int64
 }
 
 func (a *asymmSigner) SignRequest(pKey crypto.PrivateKey, pubKeyId string, r *http.Request, body []byte) error {
@@ -132,7 +139,7 @@ func (a *asymmSigner) SignRequest(pKey crypto.PrivateKey, pubKeyId string, r *ht
 	if err != nil {
 		return err
 	}
-	setSignatureHeader(r.Header, string(a.targetHeader), a.prefix, pubKeyId, a.s.String(), enc, a.headers)
+	setSignatureHeader(r.Header, string(a.targetHeader), a.prefix, pubKeyId, a.s.String(), enc, a.headers, a.created, a.expires)
 	return nil
 }
 
@@ -151,7 +158,7 @@ func (a *asymmSigner) SignResponse(pKey crypto.PrivateKey, pubKeyId string, r ht
 	if err != nil {
 		return err
 	}
-	setSignatureHeader(r.Header(), string(a.targetHeader), a.prefix, pubKeyId, a.s.String(), enc, a.headers)
+	setSignatureHeader(r.Header(), string(a.targetHeader), a.prefix, pubKeyId, a.s.String(), enc, a.headers, a.created, a.expires)
 	return nil
 }
 
@@ -165,14 +172,14 @@ func (a *asymmSigner) signSignature(pKey crypto.PrivateKey, s string) (string, e
 }
 
 func (a *asymmSigner) signatureString(r *http.Request) (string, error) {
-	return signatureString(r.Header, a.headers, addRequestTarget(r))
+	return signatureString(r.Header, a.headers, addRequestTarget(r), a.created, a.expires)
 }
 
 func (a *asymmSigner) signatureStringResponse(r http.ResponseWriter) (string, error) {
-	return signatureString(r.Header(), a.headers, requestTargetNotPermitted)
+	return signatureString(r.Header(), a.headers, requestTargetNotPermitted, a.created, a.expires)
 }
 
-func setSignatureHeader(h http.Header, targetHeader, prefix, pubKeyId, algo, enc string, headers []string) {
+func setSignatureHeader(h http.Header, targetHeader, prefix, pubKeyId, algo, enc string, headers []string, created int64, expires int64) {
 	if len(headers) == 0 {
 		headers = defaultHeaders
 	}
@@ -196,6 +203,34 @@ func setSignatureHeader(h http.Header, targetHeader, prefix, pubKeyId, algo, enc
 	b.WriteString(algo)
 	b.WriteString(parameterValueDelimiter)
 	b.WriteString(parameterSeparater)
+
+        hasCreated := false
+        hasExpires := false
+        for _, h := range headers {
+                val := strings.ToLower(h)
+                if val == "(" + createdKey + ")" {
+                  hasCreated = true
+                } else if val == "(" + expiresKey + ")" {
+                  hasExpires = true
+                }
+	}
+
+        // Created
+        if hasCreated == true {
+          b.WriteString(createdKey)
+          b.WriteString(parameterKVSeparater)
+          b.WriteString(strconv.FormatInt(created, 10))
+	  b.WriteString(parameterSeparater)
+        }
+
+        // Expires
+        if hasExpires == true {
+          b.WriteString(expiresKey)
+          b.WriteString(parameterKVSeparater)
+          b.WriteString(strconv.FormatInt(expires, 10))
+	  b.WriteString(parameterSeparater)
+        }
+
 	// Headers
 	b.WriteString(headersParameter)
 	b.WriteString(parameterKVSeparater)
@@ -238,7 +273,7 @@ func addRequestTarget(r *http.Request) func(b *bytes.Buffer) error {
 	}
 }
 
-func signatureString(values http.Header, include []string, requestTargetFn func(b *bytes.Buffer) error) (string, error) {
+func signatureString(values http.Header, include []string, requestTargetFn func(b *bytes.Buffer) error, created int64, expires int64) (string, error) {
 	if len(include) == 0 {
 		include = defaultHeaders
 	}
@@ -250,6 +285,20 @@ func signatureString(values http.Header, include []string, requestTargetFn func(
 			if err != nil {
 				return "", err
 			}
+                } else if i == "(" + expiresKey + ")" {
+                        if expires == 0 {
+                          return "", fmt.Errorf("mssing expires value")
+                        }
+                        b.WriteString(i)
+                        b.WriteString(headerFieldDelimiter)
+                        b.WriteString(strconv.FormatInt(expires, 10))
+                } else if i == "(" + createdKey + ")" {
+                        if created == 0 {
+                          return "", fmt.Errorf("mssing created value")
+                        }
+                        b.WriteString(i)
+                        b.WriteString(headerFieldDelimiter)
+                        b.WriteString(strconv.FormatInt(created, 10))
 		} else {
 			hv, ok := values[textproto.CanonicalMIMEHeaderKey(i)]
 			if !ok {


### PR DESCRIPTION
Resolves #11.

See current draft https://tools.ietf.org/html/draft-cavage-http-signatures-12.

During verifying we also check if created was in the future and if expires is in the past (with an allowed clock sync offset of 10 seconds).