### PR TITLE
hide real algorithm

### DIFF
--- a/signing.go
+++ b/signing.go
@@ -188,12 +188,11 @@ func setSignatureHeader(h http.Header, targetHeader, prefix, pubKeyId, algo, enc
 	b.WriteString(pubKeyId)
 	b.WriteString(parameterValueDelimiter)
 	b.WriteString(parameterSeparater)
-	// Algorithm (deprecated)
-	// TODO: Remove this.
+	// Algorithm
 	b.WriteString(algorithmParameter)
 	b.WriteString(parameterKVSeparater)
 	b.WriteString(parameterValueDelimiter)
-	b.WriteString(algo)
+	b.WriteString("hs2019") //real algorithm is hidden, see newest version of spec draft
 	b.WriteString(parameterValueDelimiter)
 	b.WriteString(parameterSeparater)
 	// Headers


### PR DESCRIPTION
As specified in the newest version of the specification draft we should only use hs2019 as algorithm name in the algorithm header effectively hiding the real used algorithm.

For verifying nothing changes since we already provide a custom algorithm based on keyId for verification.