### PR TITLE
Replace travis ci with github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Go Test
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  build:
+    name: Test on Go ${{ matrix.go-version }} and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        os: [ubuntu-latest]
+    steps:
+      - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Run tests
+        env:
+          GO111MODULE: on
+        run: |
+          go test -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: go
-go:
-  - 1.15


### PR DESCRIPTION
https://travis-ci.org/ discontinued: `Since June 15th, 2021, the building on http://www.travis-ci.org/ is ceased. Please use http://www.travis-ci.com/ from now on.`

Instead add pipeline for Github actions.