### PR TITLE
algorithms: fix dropped error

### DIFF
--- a/algorithms.go
+++ b/algorithms.go
@@ -148,6 +148,9 @@ type hmacAlgorithm struct {
 
 func (h *hmacAlgorithm) Sign(sig, key []byte) ([]byte, error) {
 	hs, err := h.fn(key)
+	if err != nil {
+		return nil, err
+	}
 	if err = setSig(hs, sig); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes a dropped error in `algorithms.go`.